### PR TITLE
Fixing bug related to news items with null isodate and updated fiels

### DIFF
--- a/cubanewsjs/cubanews-crawler/run.sh
+++ b/cubanewsjs/cubanews-crawler/run.sh
@@ -1,13 +1,8 @@
-# source /home/sergio/.bashrc;
 
-echo "$(date) Refreshing feed Locally" > ~/cubanews-crawler.log 2>&1;
-cd /home/sergio/github/cubanews/cubanewsjs/ddc-crawler && npm run start > ~/cubanews-crawler.log 2>&1;
-cd /home/sergio/github/cubanews/cubanewsjs/adncuba-crawler && npm run start > ~/cubanews-crawler.log 2>&1;
-cd /home/sergio/github/cubanews/cubanewsjs/catorceYmedio-crawler && npm run start > ~/cubanews-crawler.log 2>&1;
-cd /home/sergio/github/cubanews/cubanewsjs/cibercuba-crawler && npm run start > ~/cubanews-crawler.log 2>&1;
-cd /home/sergio/github/cubanews/cubanewsjs/cubanews-feed && npm run start:local > ~/cubanews-crawler.log 2>&1;
+echo "$(date) Refreshing feed Locally" > $HOME/cubanews-crawler.log 2>&1;
+cd $HOME/github/cubanews/cubanewsjs/ddc-crawler && npm run start > $HOME/cubanews-crawler.log 2>&1;
+cd $HOME/github/cubanews/cubanewsjs/adncuba-crawler && npm run start > $HOME/cubanews-crawler.log 2>&1;
+cd $HOME/github/cubanews/cubanewsjs/catorceYmedio-crawler && npm run start > $HOME/cubanews-crawler.log 2>&1;
+cd $HOME/github/cubanews/cubanewsjs/cibercuba-crawler && npm run start > $HOME/cubanews-crawler.log 2>&1;
+cd $HOME/github/cubanews/cubanewsjs/cubanews-feed && npm run start:local > $HOME/cubanews-crawler.log 2>&1;
 echo "$(date) Comleted Refreshing feed Locally" > ~/cubanews-crawler.log 2>&1;
-# # node /home/sergio/github/cubanews/cubanewsjs/adncuba-crawler/dist/main.js;
-# cd /home/sergio/github/cubanews/cubanewsjs/catorceYmedio-crawler && npm run start;
-# cd /home/sergio/github/cubanews/cubanewsjs/cibercuba-crawler && npm run start;
-# cd /home/sergio/github/cubanews/cubanewsjs/cubanews-feed && npm run start:local;

--- a/cubanewsjs/cubanews-crawler/src/catorceYMedioCrawler.ts
+++ b/cubanewsjs/cubanews-crawler/src/catorceYMedioCrawler.ts
@@ -2,6 +2,7 @@ import { CubanewsCrawler } from "./cubanewsCrawler.js";
 import { NewsSourceName, getNewsSourceByName } from "./crawlerUtils.js";
 import moment from "moment";
 import { Page } from "playwright";
+import log from "@apify/log";
 
 export default class CatorceYMedioCrawler extends CubanewsCrawler {
   constructor() {
@@ -18,17 +19,25 @@ export default class CatorceYMedioCrawler extends CubanewsCrawler {
   protected override async extractDate(
     page: Page
   ): Promise<moment.Moment | null> {
-    const rawDate = await page.locator(".timestamp-atom").first().textContent();
-    if (!rawDate) {
+    try {
+      const rawDate = await page
+        .locator(".timestamp-atom")
+        .first()
+        .textContent();
+      if (!rawDate) {
+        return null;
+      }
+      const mDate = moment(rawDate, "DD [de] MMMM YYYY - HH:mm");
+      // TODO:: Sometimes the date is in the future. This is a patch to prevent that from happening.
+      // It may be a parsing error.
+      if (mDate.isSameOrAfter(moment.now())) {
+        return moment(new Date());
+      }
+      return mDate;
+    } catch (error: any) {
+      log.error(`Error extracting date from ${page.url}`, { error: error });
       return null;
     }
-    const mDate = moment(rawDate, "DD [de] MMMM YYYY - HH:mm");
-    // TODO:: Sometimes the date is in the future. This is a patch to prevent that from happening.
-    // It may be a parsing error.
-    if (mDate.isSameOrAfter(moment.now())) {
-      return moment(new Date());
-    }
-    return mDate;
   }
 
   protected override async extractContent(page: Page): Promise<string | null> {

--- a/cubanewsjs/cubanews-crawler/src/cubanewsCrawler.ts
+++ b/cubanewsjs/cubanews-crawler/src/cubanewsCrawler.ts
@@ -75,7 +75,7 @@ export abstract class CubanewsCrawler
     if (request.loadedUrl && this.isUrlValid(request.loadedUrl)) {
       const momentDate = await this.extractDate(page);
 
-      if (momentDate) {
+      if (momentDate && momentDate.toISOString()) {
         var content = await this.extractContent(page);
         if (!content || content?.length < 100) {
           // This is to guarantee this is a real article.
@@ -96,6 +96,8 @@ export abstract class CubanewsCrawler
             process.env.NODE_ENV !== "dev"
           );
         }
+      } else {
+        log.error(`Could not extract date from ${request.loadedUrl}`);
       }
     }
 

--- a/cubanewsjs/cubanews-feed/src/app/api/feed/feedStrategies.ts
+++ b/cubanewsjs/cubanews-feed/src/app/api/feed/feedStrategies.ts
@@ -34,7 +34,7 @@ export async function xOfEachSource(
   FROM (
    SELECT *, ROW_NUMBER() OVER (PARTITION BY
    source ORDER BY updated desc) AS row_number
-   FROM feed where feedts = ${feedts}
+   FROM feed where isodate is not null AND updated is not null AND feedts = ${feedts}
   ) AS t
   WHERE t.row_number > ${pageSize * (page - 1)} AND t.row_number <= ${
     pageSize * page
@@ -55,6 +55,8 @@ export async function allSortedByUpdated(
     .selectFrom("feed")
     .selectAll()
     .where("feed.feedts", "=", feedts)
+    .where("isodate", "!=", null)
+    .where("updated", "!=", null)
     .orderBy("updated desc")
     .offset((page - 1) * pageSize)
     .limit(pageSize)

--- a/cubanewsjs/cubanews-feed/src/app/components/NewsItem.tsx
+++ b/cubanewsjs/cubanews-feed/src/app/components/NewsItem.tsx
@@ -12,6 +12,9 @@ import {
 import { NewsItem, NewsSourceDisplayName, NewsSourceName } from "../interfaces";
 import moment from "moment";
 import Image from "next/image";
+import "moment/locale/es";
+
+moment.locale("es");
 
 type NewsItemProps = {
   item: NewsItem;


### PR DESCRIPTION
For some reason when querying 14 y medio one article got saved with updated and isodate fields set to null
This caused all sorts of problems downstream, completely breaking the site.
This pull requests puts double and triple checks to ensure that cases like that are either prevented or handled accordingly if they occur.

Clean up the local script
Changes the date message to Spanish